### PR TITLE
Use builtins module

### DIFF
--- a/install-requires
+++ b/install-requires
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
-var repl = require('repl');
-var builtins = repl._builtinLibs
-builtins.push('repl');
+var builtins = require('builtins');
 
 var cp = require('child_process');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "bin": "./install-requires",
   "dependencies": {
+    "builtins": "^1.0.3",
     "find-requires": "^0.2.2"
   },
   "license": "ISC",


### PR DESCRIPTION
This patch replaces `repl._builtinLibs` hack with the use of [`builtins`](https://github.com/juliangruber/builtins) module.

`repl._builtinLibs` property is not documented and hence can change anytime, and it also lacks a bunch of modules ([not only `repl`](https://github.com/latentflip/install-deps/blob/cb2cc9e5e27d9735183de82de418c510279f6600/install-requires#L5)):

```
$ diff <(node -pe 'JSON.stringify(require("repl")._builtinLibs, null, 2)') <(npm-get builtins builtins.json)
5a6,7
>   "console",
>   "constants",
13a16
>   "module",
16a20
>   "process",
19a24
>   "repl",
21a27
>   "timers",
```

For example, for this script:

```
var timers = require('timers');

console.dir(timers);
```

install-deps installs the `timers` module from npm:

```
$ install-deps script.js
/tmp/example
└── timers@0.1.1
```

but `timers` is [part of the core](https://nodejs.org/api/timers.html), so it shouldn't have.

See also some discussion in juliangruber/builtins#2.
